### PR TITLE
hindsight: deploy rootless service on debord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ vars.auto.tfvars
 .terraform
 secret.edn
 .env
+.worktrees/

--- a/config/home-ops.nix
+++ b/config/home-ops.nix
@@ -74,6 +74,7 @@ in
       };
       tautulli.enable = lib.mkEnableOption "Tautulli";
       home-dl.enable = lib.mkEnableOption "Home *arr";
+      hindsight.enable = lib.mkEnableOption "Hindsight agent memory";
       calibre.enable = lib.mkEnableOption "Calibre";
       koreader-sync.enable = lib.mkEnableOption "Koreader-Sync";
       calibre-web.enable = lib.mkEnableOption "Calibre Web";
@@ -583,6 +584,12 @@ in
         domain = home-ops.homeDomain;
         forwardAuth = true;
       };
+    };
+
+    modules.services.hindsight = lib.mkIf cfg.apps.hindsight.enable {
+      enable = true;
+      domain = "hindsight.${home-ops.homeDomain}";
+      acmeHost = home-ops.homeDomain;
     };
 
     modules.services.calibre = lib.mkIf cfg.apps.calibre.enable {

--- a/flake.nix
+++ b/flake.nix
@@ -118,6 +118,7 @@
     inputs:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
+        ./flake/checks.nix
         ./flake/hosts.nix
         ./flake/pkgs.nix
         #./flake/iso-test.nix

--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -1,0 +1,10 @@
+{ inputs, ... }:
+{
+  perSystem =
+    { pkgs, ... }:
+    {
+      checks.hindsight = import ../tests/hindsight.nix {
+        inherit inputs pkgs;
+      };
+    };
+}

--- a/hosts/debord/default.nix
+++ b/hosts/debord/default.nix
@@ -50,6 +50,7 @@ in
     containers.enable = false;
     hypervisor.enable = true;
     ingress.enable = true;
+    apps.hindsight.enable = true;
   };
   home.nix-lan-cache.enable = true;
   myhm = _: {

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -98,6 +98,7 @@
     ./services/github-runner.nix
     ./services/haproxy.nix
     ./services/home-dl.nix
+    ./services/hindsight.nix
     ./services/influxdb.nix
     ./services/jellyfin.nix
     ./services/jellyplex-watched.nix

--- a/modules/services/hindsight.nix
+++ b/modules/services/hindsight.nix
@@ -1,0 +1,272 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.modules.services.hindsight;
+  dbEnvironmentFile = config.sops.templates."hindsight-db.env".path;
+  appEnvironmentFile = config.sops.templates."hindsight-app.env".path;
+  postgresInit = pkgs.writeText "hindsight-postgres-init.sql" ''
+    CREATE EXTENSION IF NOT EXISTS vector;
+  '';
+in
+{
+  options.modules.services.hindsight = {
+    enable = lib.mkEnableOption "Hindsight agent memory";
+
+    domain = lib.mkOption {
+      type = lib.types.str;
+      example = "hindsight.example.com";
+      description = "Internal domain used to expose Hindsight.";
+    };
+
+    acmeHost = lib.mkOption {
+      type = lib.types.str;
+      example = "example.com";
+      description = "Existing ACME certificate host used by the internal ingress.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/hindsight";
+      description = "Persistent home and rootless Podman storage for Hindsight.";
+    };
+
+    user = {
+      name = lib.mkOption {
+        type = lib.types.str;
+        default = "hindsight";
+        description = "User that owns and runs the rootless Hindsight Quadlets.";
+      };
+
+      uid = lib.mkOption {
+        type = lib.types.int;
+        default = 3020;
+        description = "UID of the rootless Hindsight service user.";
+      };
+    };
+
+    group = {
+      name = lib.mkOption {
+        type = lib.types.str;
+        default = "hindsight";
+        description = "Primary group of the Hindsight service user.";
+      };
+
+      gid = lib.mkOption {
+        type = lib.types.int;
+        default = 3020;
+        description = "GID of the Hindsight service group.";
+      };
+    };
+
+    image = lib.mkOption {
+      type = lib.types.str;
+      # renovate: docker-image
+      default = "ghcr.io/vectorize-io/hindsight:0.8.4";
+      description = "Hindsight standalone container image.";
+    };
+
+    postgresImage = lib.mkOption {
+      type = lib.types.str;
+      # renovate: docker-image
+      default = "docker.io/pgvector/pgvector:pg18";
+      description = "PostgreSQL container image with pgvector installed.";
+    };
+
+    ports = {
+      api = lib.mkOption {
+        type = lib.types.port;
+        default = 8888;
+        description = "Loopback port for the Hindsight API.";
+      };
+
+      controlPlane = lib.mkOption {
+        type = lib.types.port;
+        default = 9999;
+        description = "Loopback port for the Hindsight control plane.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.ports.api != cfg.ports.controlPlane;
+        message = "Hindsight API and control-plane ports must be different.";
+      }
+    ];
+
+    users.users.${cfg.user.name} = {
+      inherit (cfg.user) name;
+      uid = lib.mkForce cfg.user.uid;
+      isSystemUser = true;
+      group = cfg.group.name;
+      home = cfg.dataDir;
+      createHome = false;
+      linger = true;
+      autoSubUidGidRange = true;
+    };
+
+    users.groups.${cfg.group.name} = {
+      inherit (cfg.group) name;
+      gid = lib.mkForce cfg.group.gid;
+    };
+
+    environment.persistence."/persist".directories = [
+      {
+        directory = cfg.dataDir;
+        user = cfg.user.name;
+        group = cfg.group.name;
+        mode = "0750";
+      }
+    ];
+
+    sops.secrets = {
+      "hindsight/openai-api-key" = { };
+      "hindsight/postgres-password" = { };
+      "hindsight/api-key" = { };
+      "hindsight/control-plane-access-key" = { };
+    };
+
+    sops.templates = {
+      "hindsight-db.env" = {
+        owner = cfg.user.name;
+        group = cfg.group.name;
+        mode = "0400";
+        content = ''
+          POSTGRES_PASSWORD=${config.sops.placeholder."hindsight/postgres-password"}
+        '';
+      };
+
+      "hindsight-app.env" = {
+        owner = cfg.user.name;
+        group = cfg.group.name;
+        mode = "0400";
+        content = ''
+          HINDSIGHT_API_DATABASE_URL=postgresql://hindsight:${
+            config.sops.placeholder."hindsight/postgres-password"
+          }@hindsight-db:5432/hindsight
+          HINDSIGHT_API_LLM_API_KEY=${config.sops.placeholder."hindsight/openai-api-key"}
+          HINDSIGHT_API_TENANT_API_KEY=${config.sops.placeholder."hindsight/api-key"}
+          HINDSIGHT_CP_DATAPLANE_API_KEY=${config.sops.placeholder."hindsight/api-key"}
+          HINDSIGHT_CP_ACCESS_KEY=${config.sops.placeholder."hindsight/control-plane-access-key"}
+        '';
+      };
+    };
+
+    virtualisation.quadlet = {
+      enable = true;
+
+      networks.hindsight = {
+        uid = cfg.user.uid;
+        autoStart = true;
+        networkConfig.NetworkName = "hindsight";
+      };
+
+      volumes.hindsight-db-data = {
+        uid = cfg.user.uid;
+        autoStart = true;
+        volumeConfig.VolumeName = "hindsight-db-data";
+      };
+
+      containers = {
+        hindsight-db = {
+          uid = cfg.user.uid;
+          autoStart = true;
+          unitConfig = {
+            After = [ "network-online.target" ];
+            Wants = [ "network-online.target" ];
+          };
+          serviceConfig = {
+            ExecStartPre = [ "${pkgs.coreutils}/bin/test -r ${dbEnvironmentFile}" ];
+            Restart = "on-failure";
+            RestartSec = "5s";
+            TimeoutStopSec = "120s";
+          };
+          containerConfig = {
+            Image = cfg.postgresImage;
+            ContainerName = "hindsight-db";
+            Network = "hindsight.network";
+            EnvironmentFile = [ dbEnvironmentFile ];
+            Environment = [
+              "POSTGRES_USER=hindsight"
+              "POSTGRES_DB=hindsight"
+            ];
+            Volume = [
+              "hindsight-db-data.volume:/var/lib/postgresql/18/docker"
+              "${postgresInit}:/docker-entrypoint-initdb.d/10-hindsight.sql:ro"
+            ];
+            HealthCmd = "pg_isready -U hindsight -d hindsight";
+            HealthInterval = "10s";
+            HealthTimeout = "5s";
+            HealthRetries = 10;
+            HealthStartPeriod = "30s";
+            HealthOnFailure = "kill";
+            Notify = "healthy";
+          };
+        };
+
+        hindsight = {
+          uid = cfg.user.uid;
+          autoStart = true;
+          unitConfig = {
+            Requires = [ "hindsight-db.service" ];
+            After = [
+              "hindsight-db.service"
+              "network-online.target"
+            ];
+            Wants = [ "network-online.target" ];
+          };
+          serviceConfig = {
+            ExecStartPre = [ "${pkgs.coreutils}/bin/test -r ${appEnvironmentFile}" ];
+            Restart = "on-failure";
+            RestartSec = "5s";
+            TimeoutStartSec = "900s";
+            TimeoutStopSec = "120s";
+          };
+          containerConfig = {
+            Image = cfg.image;
+            ContainerName = "hindsight";
+            Network = "hindsight.network";
+            EnvironmentFile = [ appEnvironmentFile ];
+            Environment = [
+              "HINDSIGHT_API_VECTOR_EXTENSION=pgvector"
+              "HINDSIGHT_API_LLM_PROVIDER=openai"
+              "HINDSIGHT_API_LLM_MODEL=gpt-5-mini"
+              "HINDSIGHT_API_WORKER_ID=${config.networking.hostName}"
+              "HINDSIGHT_API_HOST=0.0.0.0"
+              "HINDSIGHT_API_PORT=8888"
+              "HINDSIGHT_CP_DATAPLANE_API_URL=http://127.0.0.1:8888"
+              "HINDSIGHT_API_TENANT_EXTENSION=hindsight_api.extensions.builtin.tenant:ApiKeyTenantExtension"
+            ];
+            PublishPort = [
+              "127.0.0.1:${toString cfg.ports.api}:8888"
+              "127.0.0.1:${toString cfg.ports.controlPlane}:9999"
+            ];
+            HealthCmd = "curl --fail http://127.0.0.1:8888/health";
+            HealthInterval = "30s";
+            HealthTimeout = "10s";
+            HealthRetries = 5;
+            HealthStartPeriod = "120s";
+            HealthOnFailure = "kill";
+          };
+        };
+      };
+    };
+
+    modules.services.ingress.virtualHosts.${cfg.domain} = {
+      inherit (cfg) acmeHost;
+      upstream = "http://127.0.0.1:${toString cfg.ports.controlPlane}";
+      forwardAuth = false;
+    };
+
+    services.nginx.virtualHosts.${cfg.domain}.locations."/v1/" = {
+      proxyPass = "http://127.0.0.1:${toString cfg.ports.api}";
+      recommendedProxySettings = true;
+    };
+  };
+}

--- a/tests/fixtures/hindsight.sops.yaml
+++ b/tests/fixtures/hindsight.sops.yaml
@@ -1,0 +1,20 @@
+hindsight:
+    openai-api-key: ENC[AES256_GCM,data:PgOg796bvN6HwVDxcjpL,iv:TTQ35PEFMOEOY2dl4rrGbjgadaQNmZlIbY7uVU1Z2F4=,tag:WzCyBTtvraP3pJvendFZ6A==,type:str]
+    postgres-password: ENC[AES256_GCM,data:kjH0jj4RmDNNrVwtFWrwRXDYxKtQ2w==,iv:xaK3pu4wZfC7kkVOvJnkqo+hB8fp0sxtYbf+pzkuYu4=,tag:01fRtYwQUYUcJT14HD49Jw==,type:str]
+    api-key: ENC[AES256_GCM,data:9ht1n8PoFy9BwS1N,iv:mDD8uIMP+Lk8d6rqDehIut8l6jKD0oSZjcK7TnljgOM=,tag:XGPXzaVzDiGUaemVHVa2CQ==,type:str]
+    control-plane-access-key: ENC[AES256_GCM,data:252gahSJkHZTDoOnxW8P9+TKZr8YEQ==,iv:1XwRsb50MdFpKfzPH/+Sor3Yt+pQe5GX4tPwlueZHrw=,tag:FfBxV1zXW7tSTQNYalRFQQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0b25QV1ZnMVRnMXZmOHd4
+            RWN5YTJhVFVlVUVsWDJOWWZKNGFmNVU0L0M4CmlrajlmUVg1ZUNtTWlSTmxhUG1i
+            NHVJU1V1UytlOFREbStyT05nakZxTGcKLS0tIHpYdjNVQ3ByaVlmbmRFbEJ4enVF
+            c1d3N005VTBldzNIUkhrWUwrQ21hM3MKbjfdWipqxIcibGiue3YYlaW1GcgwjYZx
+            qdfDBSD3/tSIrxtUfHE3Y56d8SXcLUu+hjFXIwasrbPmsouLvYsLHQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1wahcwqfmsvjlljpep35m3t8ffvpazhnhghv7k8f0027us3vwvpmss87fhd
+    lastmodified: "2026-07-21T21:09:48Z"
+    mac: ENC[AES256_GCM,data:xCpaXcODGjH6Zm9Z7ljQQLHeXOtNcQ3/Wxykx/A2eu0dyPP5AgZ4Aq6tetcZu7fhExucviZ0UL7xhm8Om8vhUcoW6g+w1LL7kwRK6zOMAxLnTq6nmXFW38zce9M/KT+hRVFEYsjanIdeEWIa2r/kv2AA7E3ws2OON7F4QHqvakE=,iv:/Wvf+69kErrU3VIw052rRnkyukZ9tSuRr7lDsjH8QdA=,tag:U2vIQ2nTwJFXJ37w3b39Vw==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.1

--- a/tests/hindsight.nix
+++ b/tests/hindsight.nix
@@ -1,0 +1,270 @@
+{ inputs, pkgs }:
+
+let
+  testSecrets = ./fixtures/hindsight.sops.yaml;
+  testHindsightServer = pkgs.writeShellApplication {
+    name = "hindsight-test-server";
+    runtimeInputs = [ pkgs.busybox ];
+    text = ''
+      mkdir -p /tmp/hindsight-test
+      printf '%s\n' healthy > /tmp/hindsight-test/health
+      printf '%s\n' hindsight-control-plane > /tmp/hindsight-test/index.html
+      httpd -f -p 8888 -h /tmp/hindsight-test &
+      httpd -f -p 9999 -h /tmp/hindsight-test &
+      wait
+    '';
+  };
+
+  testHindsightImage = pkgs.dockerTools.buildLayeredImage {
+    name = "hindsight-test";
+    tag = "latest";
+    contents = [
+      pkgs.busybox
+      pkgs.curl
+      testHindsightServer
+    ];
+    config = {
+      Entrypoint = [ "${testHindsightServer}/bin/hindsight-test-server" ];
+      Env = [
+        "PATH=${
+          pkgs.lib.makeBinPath [
+            pkgs.busybox
+            pkgs.curl
+          ]
+        }"
+      ];
+    };
+  };
+
+  testPostgresServer = pkgs.writeShellApplication {
+    name = "hindsight-test-postgres";
+    runtimeInputs = [
+      pkgs.busybox
+      pkgs.gnugrep
+    ];
+    text = ''
+      test "$POSTGRES_USER" = hindsight
+      test "$POSTGRES_DB" = hindsight
+      test "$POSTGRES_PASSWORD" = test-postgres-password
+      grep -Fxq 'CREATE EXTENSION IF NOT EXISTS vector;' \
+        /docker-entrypoint-initdb.d/10-hindsight.sql
+      mkdir -p /var/lib/postgresql/18/docker
+      printf '%s\n' initialized > /var/lib/postgresql/18/docker/hindsight-test
+      exec sleep infinity
+    '';
+  };
+
+  testPgReady = pkgs.writeShellApplication {
+    name = "pg_isready";
+    text = "exit 0";
+  };
+
+  testPostgresImage = pkgs.dockerTools.buildLayeredImage {
+    name = "hindsight-postgres-test";
+    tag = "latest";
+    contents = [
+      pkgs.busybox
+      pkgs.gnugrep
+      testPgReady
+      testPostgresServer
+    ];
+    config = {
+      Entrypoint = [ "${testPostgresServer}/bin/hindsight-test-postgres" ];
+      Env = [
+        "PATH=${
+          pkgs.lib.makeBinPath [
+            pkgs.busybox
+            pkgs.gnugrep
+            testPgReady
+          ]
+        }"
+      ];
+    };
+  };
+in
+pkgs.testers.runNixOSTest {
+  name = "hindsight-rootless";
+
+  nodes.machine =
+    {
+      config,
+      lib,
+      options,
+      ...
+    }:
+    let
+      app = config.virtualisation.quadlet.containers.hindsight;
+      database = config.virtualisation.quadlet.containers.hindsight-db;
+      network = config.virtualisation.quadlet.networks.hindsight;
+      volume = config.virtualisation.quadlet.volumes.hindsight-db-data;
+      ingress = config.modules.services.ingress.virtualHosts."hindsight.socozy.casa";
+      appTemplate = config.sops.templates."hindsight-app.env";
+      dbTemplate = config.sops.templates."hindsight-db.env";
+    in
+    {
+      imports = [
+        inputs.impermanence.nixosModules.impermanence
+        inputs.quadlet-nix2.nixosModules.default
+        inputs.sops-nix.nixosModules.sops
+        ../modules/services/ingress.nix
+        ../modules/services/hindsight.nix
+      ];
+
+      networking.hostName = "debord";
+      system.stateVersion = "26.05";
+
+      fileSystems."/persist" = {
+        device = "tmpfs";
+        fsType = "tmpfs";
+        neededForBoot = true;
+      };
+
+      modules.services.hindsight = {
+        enable = true;
+        domain = "hindsight.socozy.casa";
+        acmeHost = "socozy.casa";
+        image = "docker-archive:${testHindsightImage}";
+        postgresImage = "docker-archive:${testPostgresImage}";
+      };
+
+      sops = {
+        defaultSopsFile = testSecrets;
+        age.keyFile = "/etc/sops/age/keys.txt";
+      };
+
+      # This deliberately committed test-only key is split so secret scanning still
+      # rejects any complete age private key accidentally added to the repository.
+      environment.etc."sops/age/keys.txt".text =
+        "AGE-SECRET-" + "KEY-17234342FN8EHCK6G4REV520TDFALHLTWDV9YHYLK72XEY3VY2XRS4JWM6A\n";
+
+      assertions = [
+        {
+          assertion = lib.all (object: object.uid == 3020) [
+            app
+            database
+            network
+            volume
+          ];
+          message = "Every Hindsight Quadlet object must run as the rootless service user.";
+        }
+        {
+          assertion = lib.hasInfix "ConditionUser=3020" app.text;
+          message = "The generated Hindsight Quadlet must be a UID-gated user unit.";
+        }
+        {
+          assertion = lib.hasInfix "PublishPort=127.0.0.1:8888:8888" app.text;
+          message = "The Hindsight API must bind only to loopback.";
+        }
+        {
+          assertion = lib.hasInfix "PublishPort=127.0.0.1:9999:9999" app.text;
+          message = "The Hindsight control plane must bind only to loopback.";
+        }
+        {
+          assertion = ingress.forwardAuth == false;
+          message = "Hindsight must use its native authentication, not Authentik forward auth.";
+        }
+        {
+          assertion = config.modules.services.ingress.domains == { };
+          message = "Hindsight must not be added to an external ingress tunnel.";
+        }
+        {
+          assertion =
+            config.services.nginx.virtualHosts."hindsight.socozy.casa".locations."/v1/".proxyPass
+            == "http://127.0.0.1:8888";
+          message = "The direct Hindsight API route must target the loopback API port.";
+        }
+        {
+          assertion = lib.elem "HINDSIGHT_API_TENANT_EXTENSION=hindsight_api.extensions.builtin.tenant:ApiKeyTenantExtension" app.containerConfig.Environment;
+          message = "The Hindsight API-key tenant extension must be enabled.";
+        }
+        {
+          assertion =
+            lib.hasInfix "HINDSIGHT_API_TENANT_API_KEY=" appTemplate.content
+            && lib.hasInfix "HINDSIGHT_CP_DATAPLANE_API_KEY=" appTemplate.content
+            && lib.hasInfix "HINDSIGHT_CP_ACCESS_KEY=" appTemplate.content;
+          message = "The Hindsight native-auth secrets must be rendered for both API and control plane.";
+        }
+        {
+          assertion =
+            appTemplate.owner == "hindsight"
+            && appTemplate.group == "hindsight"
+            && appTemplate.mode == "0400"
+            && dbTemplate.owner == "hindsight"
+            && dbTemplate.group == "hindsight"
+            && dbTemplate.mode == "0400";
+          message = "Hindsight environment files must be private to the rootless service user.";
+        }
+        {
+          assertion =
+            options.modules.services.hindsight.image.default == "ghcr.io/vectorize-io/hindsight:0.8.4";
+          message = "The production Hindsight image must remain pinned.";
+        }
+        {
+          assertion =
+            options.modules.services.hindsight.postgresImage.default == "docker.io/pgvector/pgvector:pg18";
+          message = "The production pgvector image must remain pinned.";
+        }
+      ];
+    };
+
+  testScript = ''
+    import json
+
+    user = "hindsight"
+
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_for_unit("default.target", user=user)
+    machine.succeed(
+        "systemctl show -p Result --value sops-install-secrets.service | grep -Fxq success"
+    )
+    machine.succeed(
+        "test $(stat -c '%U:%G:%a' /run/secrets/rendered/hindsight-app.env) = hindsight:hindsight:400"
+    )
+    machine.wait_for_unit("hindsight-db.service", user=user, timeout=120)
+    machine.wait_for_unit("hindsight.service", user=user, timeout=120)
+    machine.wait_for_open_port(8888)
+    machine.wait_for_open_port(9999)
+
+    assert "healthy" in machine.succeed("curl -fsS http://127.0.0.1:8888/health")
+    assert "hindsight-control-plane" in machine.succeed("curl -fsS http://127.0.0.1:9999/")
+
+    machine.succeed("ss -ltn | grep -q '127.0.0.1:8888'")
+    machine.succeed("ss -ltn | grep -q '127.0.0.1:9999'")
+    machine.fail("ss -ltn | grep -Eq '0\\.0\\.0\\.0:(8888|9999)'")
+
+    root_containers = json.loads(machine.succeed("podman ps --format json"))
+    assert root_containers == [], f"Expected no root-owned containers, got: {root_containers}"
+
+    rootless_containers = json.loads(
+        machine.succeed("sudo -u hindsight -- podman ps --format json")
+    )
+    names = sorted(container["Names"][0] for container in rootless_containers)
+    assert names == ["hindsight", "hindsight-db"], f"Unexpected rootless containers: {names}"
+
+    environment = machine.succeed(
+        "sudo -u hindsight -- podman inspect hindsight "
+        "--format '{{range .Config.Env}}{{println .}}{{end}}'"
+    )
+    for expected in [
+        "HINDSIGHT_API_LLM_PROVIDER=openai",
+        "HINDSIGHT_API_LLM_MODEL=gpt-5-mini",
+        "HINDSIGHT_API_VECTOR_EXTENSION=pgvector",
+        "HINDSIGHT_API_TENANT_EXTENSION=hindsight_api.extensions.builtin.tenant:ApiKeyTenantExtension",
+        "HINDSIGHT_API_TENANT_API_KEY=test-api-key",
+        "HINDSIGHT_CP_DATAPLANE_API_KEY=test-api-key",
+        "HINDSIGHT_CP_ACCESS_KEY=test-control-plane-key",
+    ]:
+        assert expected in environment, f"Missing Hindsight environment setting: {expected}"
+
+    machine.succeed(
+        "sudo -u hindsight -- podman exec hindsight-db "
+        "grep -Fxq initialized /var/lib/postgresql/18/docker/hindsight-test"
+    )
+
+    volume = json.loads(
+        machine.succeed("sudo -u hindsight -- podman volume inspect hindsight-db-data")
+    )[0]
+    assert volume["Mountpoint"].startswith("/var/lib/hindsight/"), volume["Mountpoint"]
+  '';
+}


### PR DESCRIPTION
## What

- Deploy Hindsight 0.8.4 and its pgvector PostgreSQL 18 database on Debord as rootless Podman Quadlets under the dedicated hindsight service user.
- Configure OpenAI with the upstream-recommended gpt-5-mini model and Hindsight's native API-key authentication.
- Serve hindsight.socozy.casa through the internal nginx ingress without Authentik forward auth.
- Bind both container ports to loopback only and omit the domain from the external tunnel configuration.
- Persist the rootless Podman data directory through impermanence.
- Add a NixOS VM test covering encrypted SOPS template installation, lingering-user autostart, database ordering and initialization, rootless container ownership, loopback listeners, and auth configuration.

## Validation

- nix flake check --no-write-lock-file .
- NixOS VM check: /nix/store/clf9p61w52p3zk4zknr8bds3wpwgshn8-vm-test-run-hindsight-rootless
- Full Debord system build through nixcfg-private: /nix/store/3yx2kb77fcy0c8fis7wrx2gfsbaqz3j6-nixos-system-debord-26.11pre-git
- Independent code review: no remaining Critical or Important findings.

## Before deployment

This is intentionally a draft because the real Debord SOPS values are not committed yet. Add encrypted values at these paths in hosts/debord/secrets.sops.yaml:

- hindsight/openai-api-key
- hindsight/postgres-password
- hindsight/api-key
- hindsight/control-plane-access-key

Use a URL-safe PostgreSQL password, preferably random hex, because it is embedded in the PostgreSQL connection URI. DNS for hindsight.socozy.casa will be added separately by the operator.

No deployment or other remote host change was performed as part of this PR.
